### PR TITLE
adding a privilege to enable the use of Alsa via Gstreamer in lieu of…

### DIFF
--- a/config.xml.in
+++ b/config.xml.in
@@ -9,6 +9,7 @@
   <feature name="urn:AGL:widget:required-permission">
     <param name="urn:AGL:permission::public:hidden" value="required" />
     <param name="http://tizen.org/privilege/internal/dbus" value="required" />
+    <param name="urn:AGL:permission:audio:public:audiostream" value="required" />
   </feature>
   <feature name="urn:AGL:widget:provided-api">
      <param name="naviapi" value="ws" />


### PR DESCRIPTION
Until now the default to play in AGL is to use pulseaudio but with 4a using Alsa is preferable.
In order to not be constrains by HW configuration, I use gstreamer in order to convert Audio in the required number of Channel (e.g. 2 for my USB-Audio test kit).
A generic privilege is required but soon specific privilege will be needed to access specific Audio role.

Signed-off-by: Dominig ar Foll Intel Open Source <dominig.arfoll@fridu.net>